### PR TITLE
DPJTH-1 Add password loading support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ dependency-reduced-pom.xml
 *.l4je
 *.l4j
 
+# Java properties files
+*.properties
+
 # Files in the archetype that should not be ignored by more general rules
 !.settings/net.sf.jautodoc.prefs
 !.settings/org.eclipse.core.resources.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ dependency-reduced-pom.xml
 !.settings/org.eclipse.m2e.core.prefs
 !src/main/resources/com/datalogics/pdf/hsm/samples/pdfjavatoolkit-ds.pdf
 !user-documentation.pdf
+!src/test/resources/com/datalogics/pdf/hsm/samples/util/test.properties
 
 ### OSX ###
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ evaluating Datalogics PDF Java Toolkit.
 * To use these samples, you will need an HSM device, and the associated JARs and development software provided by the HSM supplier. Currently supported HSM devices:
   * [_SafeNet Network/LunaSA HSM_](http://www.safenet-inc.com/data-encryption/hardware-security-modules-hsms/luna-hsms-key-management/luna-sa-network-hsm/)
 
+## Providing an HSM password
+You will need to supply a login password for your HSM device. The sample is written to retrieve the password from a properties file. This file is not included in the repo—you will need to add it to your system.
+
+By default, this file is named `hsm.properties` and contains a single entry:
+
+    hsm.password=SPAAbQDhVOzF+t9ANEg
+
+It will search for this file in the current working directory, or the user's home directory, in that order.
+
 ## Using with an evaluation version of PDFJT
 
 The evaluation version of PDF Java Toolkit has license management, and a different artifact name: ``pdfjt-lm``. There's also a corresponding ``talkeetna-lm`` which similarly depends on ``pdfjt-lm``. Switching to use these versions of PDF Java Toolkit and Talkeetna is provided with Maven profiles.

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <version>2.4</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>findbugs-annotations</artifactId>
       <version>3.0.1</version>
@@ -106,6 +111,11 @@
       <groupId>com.safenetinc.luna</groupId>
       <artifactId>provider</artifactId>
       <version>5.2.0</version>
+    </dependency>
+    <dependency>
+    	<groupId>commons-beanutils</groupId>
+    	<artifactId>commons-beanutils</artifactId>
+    	<version>1.9.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,9 @@
       <version>5.2.0</version>
     </dependency>
     <dependency>
-    	<groupId>commons-beanutils</groupId>
-    	<artifactId>commons-beanutils</artifactId>
-    	<version>1.9.2</version>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
@@ -21,9 +21,9 @@ import com.adobe.pdfjt.services.digsig.UserInfo;
 import com.adobe.pdfjt.services.digsig.cryptoprovider.JCEProvider;
 import com.adobe.pdfjt.services.digsig.spi.CryptoContext;
 
-import com.datalogics.pdf.hsm.samples.util.ConfigurationUtils;
 import com.datalogics.pdf.hsm.samples.util.DocumentUtils;
 import com.datalogics.pdf.hsm.samples.util.IoUtils;
+import com.datalogics.pdf.hsm.samples.util.SampleConfigurationUtils;
 import com.datalogics.pdf.security.HsmManager;
 import com.datalogics.pdf.security.HsmManagerFactory;
 import com.datalogics.pdf.security.LunaHsmLoginParameters;
@@ -83,7 +83,7 @@ public final class HsmSignDocument {
         LicenseManager.setLicensePath(".");
 
         // Retrieve the password, stored in the hsm.properties file
-        final Configuration loginConfiguration = ConfigurationUtils.getConfiguration(PROPERTIES_FILE);
+        final Configuration loginConfiguration = SampleConfigurationUtils.getConfiguration(PROPERTIES_FILE);
         password = loginConfiguration.getString(PASSWORD_PROPERTY);
 
         hsmManager = HsmManagerFactory.newInstance(HsmManagerFactory.LUNA_HSM_TYPE);

--- a/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
@@ -79,13 +79,6 @@ public final class HsmSignDocument {
 
         hsmManager = HsmManagerFactory.newInstance(HsmManagerFactory.LUNA_HSM_TYPE);
 
-        URL outputUrl = null;
-        if (args.length > 0) {
-            outputUrl = new File(args[0]).toURI().toURL();
-        } else {
-            outputUrl = new File(OUTPUT_SIGNED_PDF_PATH).toURI().toURL();
-        }
-
         if (!hsmManager.isLoggedIn()) {
             // Log in to the HSM
             hsmManager.hsmLogin(new LunaHsmLoginParameters(TOKEN_LABEL, PASSWORD));
@@ -104,6 +97,13 @@ public final class HsmSignDocument {
         }
 
         final URL inputUrl = HsmSignDocument.class.getResource(INPUT_UNSIGNED_PDF_PATH);
+
+        URL outputUrl = null;
+        if (args.length > 0) {
+            outputUrl = new File(args[0]).toURI().toURL();
+        } else {
+            outputUrl = new File(OUTPUT_SIGNED_PDF_PATH).toURI().toURL();
+        }
 
         // Query and sign all permissible signature fields.
         signExistingSignatureFields(inputUrl, outputUrl);

--- a/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/HsmSignDocument.java
@@ -53,6 +53,9 @@ public final class HsmSignDocument {
     private static final String CERTIFICATE_LABEL = "pdfjt-eval-cert"; // The certificate label/alias
     private static final String DIGESTER_ALG = "SHA256";
 
+    private static final String PROPERTIES_FILE = "hsm.properties";
+    private static final String PASSWORD_PROPERTY = "hsm.password";
+
     public static final String INPUT_UNSIGNED_PDF_PATH = "UnsignedDocument.pdf";
     public static final String OUTPUT_SIGNED_PDF_PATH = "SignedField.pdf";
 
@@ -80,8 +83,8 @@ public final class HsmSignDocument {
         LicenseManager.setLicensePath(".");
 
         // Retrieve the password, stored in the hsm.properties file
-        final Configuration loginConfiguration = ConfigurationUtils.getConfiguration("hsm.properties");
-        password = loginConfiguration.getString("hsm.password");
+        final Configuration loginConfiguration = ConfigurationUtils.getConfiguration(PROPERTIES_FILE);
+        password = loginConfiguration.getString(PASSWORD_PROPERTY);
 
         hsmManager = HsmManagerFactory.newInstance(HsmManagerFactory.LUNA_HSM_TYPE);
 

--- a/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
@@ -5,10 +5,19 @@
 package com.datalogics.pdf.hsm.samples.util;
 
 import org.apache.commons.configuration2.Configuration;
-import org.apache.commons.configuration2.builder.fluent.Configurations;
+import org.apache.commons.configuration2.FileBasedConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.BasePathLocationStrategy;
+import org.apache.commons.configuration2.io.CombinedLocationStrategy;
+import org.apache.commons.configuration2.io.FileLocationStrategy;
+import org.apache.commons.configuration2.io.HomeDirectoryLocationStrategy;
+import org.apache.commons.configuration2.io.ProvidedURLLocationStrategy;
 
-import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Helper class to provide Apache Configuration objects to clients.
@@ -27,7 +36,32 @@ public final class ConfigurationUtils {
      * @throws ConfigurationException if configuration file could not be found
      */
     public static Configuration getConfiguration(final String configurationFile) throws ConfigurationException {
-        final Configurations configs = new Configurations();
-        return configs.properties(new File(configurationFile));
+        final Parameters parameters = new Parameters();
+        final FileBasedConfigurationBuilder<FileBasedConfiguration> builder = new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class)
+                                                                                                                                                                      .configure(parameters.fileBased()
+                                                                                                                                                                                           .setLocationStrategy(buildDefaultLocationStrategy())
+                                                                                                                                                                                           .setFileName(configurationFile));
+        return builder.getConfiguration();
+    }
+
+    /**
+     * Build a location strategy for finding a configuration file.
+     *
+     * <p>
+     * This strategy searches the following locations in order:
+     * <ul>
+     * <li>A provided URL</li>
+     * <li>The current working directory</li>
+     * <li>The user's home directory</li>
+     * </ul>
+     *
+     * @return a strategy for finding a configuration file
+     */
+    private static FileLocationStrategy buildDefaultLocationStrategy() {
+        final List<FileLocationStrategy> strategies = new ArrayList<FileLocationStrategy>();
+        strategies.add(new ProvidedURLLocationStrategy());
+        strategies.add(new BasePathLocationStrategy());
+        strategies.add(new HomeDirectoryLocationStrategy());
+        return new CombinedLocationStrategy(strategies);
     }
 }

--- a/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Datalogics Inc.
+ */
+
+package com.datalogics.pdf.hsm.samples.util;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.builder.fluent.Configurations;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+
+import java.io.File;
+
+/**
+ * Helper class to provide Apache Configuration objects to clients.
+ */
+public final class ConfigurationUtils {
+    /**
+     * This is a utility class, and won't be instantiated.
+     */
+    private ConfigurationUtils() {}
+
+    /**
+     * Get a configuration object.
+     *
+     * @param configurationFile name of configuration file to load
+     * @return a Configuration object
+     * @throws ConfigurationException if configuration file could not be found
+     */
+    public static Configuration getConfiguration(final String configurationFile) throws ConfigurationException {
+        final Configurations configs = new Configurations();
+        return configs.properties(new File(configurationFile));
+    }
+}

--- a/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
@@ -16,6 +16,7 @@ import org.apache.commons.configuration2.io.FileLocationStrategy;
 import org.apache.commons.configuration2.io.HomeDirectoryLocationStrategy;
 import org.apache.commons.configuration2.io.ProvidedURLLocationStrategy;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,15 +38,19 @@ public final class ConfigurationUtils {
      *
      * @param configurationFile name of configuration file to load
      * @return a Configuration object
-     * @throws ConfigurationException if configuration file could not be found
+     * @throws IOException if configuration file could not be loaded
      */
-    public static Configuration getConfiguration(final String configurationFile) throws ConfigurationException {
-        final Parameters parameters = new Parameters();
-        final FileBasedConfigurationBuilder<FileBasedConfiguration> builder = newPropertiesBuilder();
-        builder.configure(parameters.fileBased()
-                                    .setLocationStrategy(buildDefaultLocationStrategy())
-                                    .setFileName(configurationFile));
-        return builder.getConfiguration();
+    public static Configuration getConfiguration(final String configurationFile) throws IOException {
+        try {
+            final Parameters parameters = new Parameters();
+            final FileBasedConfigurationBuilder<FileBasedConfiguration> builder = newPropertiesBuilder();
+            builder.configure(parameters.fileBased()
+                                        .setLocationStrategy(buildDefaultLocationStrategy())
+                                        .setFileName(configurationFile));
+            return builder.getConfiguration();
+        } catch (final ConfigurationException e) {
+            throw new IOException("Could not load configuration file '" + configurationFile + "'", e);
+        }
     }
 
     /**

--- a/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/util/ConfigurationUtils.java
@@ -16,7 +16,7 @@ import org.apache.commons.configuration2.io.FileLocationStrategy;
 import org.apache.commons.configuration2.io.HomeDirectoryLocationStrategy;
 import org.apache.commons.configuration2.io.ProvidedURLLocationStrategy;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -31,16 +31,20 @@ public final class ConfigurationUtils {
     /**
      * Get a configuration object.
      *
+     * <p>
+     * You can specify a path to the configuration file; by default, it will search in the current working directory and
+     * the user's home directory, in that order.
+     *
      * @param configurationFile name of configuration file to load
      * @return a Configuration object
      * @throws ConfigurationException if configuration file could not be found
      */
     public static Configuration getConfiguration(final String configurationFile) throws ConfigurationException {
         final Parameters parameters = new Parameters();
-        final FileBasedConfigurationBuilder<FileBasedConfiguration> builder = new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class)
-                                                                                                                                                                      .configure(parameters.fileBased()
-                                                                                                                                                                                           .setLocationStrategy(buildDefaultLocationStrategy())
-                                                                                                                                                                                           .setFileName(configurationFile));
+        final FileBasedConfigurationBuilder<FileBasedConfiguration> builder = newPropertiesBuilder();
+        builder.configure(parameters.fileBased()
+                                    .setLocationStrategy(buildDefaultLocationStrategy())
+                                    .setFileName(configurationFile));
         return builder.getConfiguration();
     }
 
@@ -58,10 +62,13 @@ public final class ConfigurationUtils {
      * @return a strategy for finding a configuration file
      */
     private static FileLocationStrategy buildDefaultLocationStrategy() {
-        final List<FileLocationStrategy> strategies = new ArrayList<FileLocationStrategy>();
-        strategies.add(new ProvidedURLLocationStrategy());
-        strategies.add(new BasePathLocationStrategy());
-        strategies.add(new HomeDirectoryLocationStrategy());
+        final List<FileLocationStrategy> strategies = Arrays.asList(new ProvidedURLLocationStrategy(),
+                                                                    new BasePathLocationStrategy(),
+                                                                    new HomeDirectoryLocationStrategy());
         return new CombinedLocationStrategy(strategies);
+    }
+
+    private static FileBasedConfigurationBuilder<FileBasedConfiguration> newPropertiesBuilder() {
+        return new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class);
     }
 }

--- a/src/main/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtils.java
+++ b/src/main/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtils.java
@@ -23,11 +23,11 @@ import java.util.List;
 /**
  * Helper class to provide Apache Configuration objects to clients.
  */
-public final class ConfigurationUtils {
+public final class SampleConfigurationUtils {
     /**
      * This is a utility class, and won't be instantiated.
      */
-    private ConfigurationUtils() {}
+    private SampleConfigurationUtils() {}
 
     /**
      * Get a configuration object.

--- a/src/test/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtilsTest.java
+++ b/src/test/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtilsTest.java
@@ -8,10 +8,12 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.configuration2.Configuration;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -30,6 +32,11 @@ public class SampleConfigurationUtilsTest {
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
+    @BeforeClass
+    public static void setUp() throws IOException {
+        createFakeUserHomeDirectory();
+    }
+
     @AfterClass
     public static void cleanUp() throws IOException {
         removePropertiesFileFromAllDirectories();
@@ -38,6 +45,12 @@ public class SampleConfigurationUtilsTest {
     /*
      * Helper methods
      */
+    private static void createFakeUserHomeDirectory() throws IOException {
+        final File fakeUserHomeDir = new File(new File(new File("target"), "test-output"), "fake-user-home-dir");
+        Files.createDirectories(fakeUserHomeDir.toPath());
+        System.setProperty("user.home", fakeUserHomeDir.getCanonicalPath());
+    }
+
     private static Path getCurrentWorkingDirectoryPath() {
         final Path currentDir = Paths.get(System.getProperty("user.dir"));
         return currentDir.resolve(TEST_PROPERTIES_FILE);

--- a/src/test/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtilsTest.java
+++ b/src/test/java/com/datalogics/pdf/hsm/samples/util/SampleConfigurationUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Datalogics Inc.
+ */
+
+package com.datalogics.pdf.hsm.samples.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.configuration2.Configuration;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Unit tests for the SampleConfigurationUtils.
+ */
+public class SampleConfigurationUtilsTest {
+    public static final String TEST_PROPERTIES_FILE = "test.properties";
+    public static final String PROPERTY_1 = "property1";
+    public static final String PROPERTY_1_VALUE = "alpha";
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @AfterClass
+    public static void cleanUp() throws IOException {
+        removePropertiesFileFromAllDirectories();
+    }
+
+    /*
+     * Helper methods
+     */
+    private static Path getCurrentWorkingDirectoryPath() {
+        final Path currentDir = Paths.get(System.getProperty("user.dir"));
+        return currentDir.resolve(TEST_PROPERTIES_FILE);
+    }
+
+    private static Path getUserHomeDirectoryPath() {
+        final Path homeDir = Paths.get(System.getProperty("user.home"));
+        return homeDir.resolve(TEST_PROPERTIES_FILE);
+    }
+
+    private static void removePropertiesFileFromAllDirectories() throws IOException {
+        Files.deleteIfExists(getCurrentWorkingDirectoryPath());
+        Files.deleteIfExists(getUserHomeDirectoryPath());
+    }
+
+    private void copyPropertiesFileToCurrentWorkingDirectory() throws IOException {
+        removePropertiesFileFromAllDirectories();
+
+        final InputStream properties = this.getClass().getResourceAsStream(TEST_PROPERTIES_FILE);
+        Files.copy(properties, getCurrentWorkingDirectoryPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void copyPropertiesFileToUsersHomeDirectory() throws IOException {
+        removePropertiesFileFromAllDirectories();
+
+        final InputStream properties = this.getClass().getResourceAsStream(TEST_PROPERTIES_FILE);
+        Files.copy(properties, getUserHomeDirectoryPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    /*
+     * Unit tests
+     */
+    @Test
+    public void findPropertiesFileInCurrentWorkingDirectory() throws IOException {
+        copyPropertiesFileToCurrentWorkingDirectory();
+        final Configuration testConfiguration = SampleConfigurationUtils.getConfiguration(TEST_PROPERTIES_FILE);
+        assertEquals(PROPERTY_1 + " value was not correct", PROPERTY_1_VALUE, testConfiguration.getString(PROPERTY_1));
+    }
+
+    @Test
+    public void findPropertiesFileInUsersHomeDirectory() throws IOException {
+        copyPropertiesFileToUsersHomeDirectory();
+        final Configuration testConfiguration = SampleConfigurationUtils.getConfiguration(TEST_PROPERTIES_FILE);
+        assertEquals(PROPERTY_1 + " value was not correct", PROPERTY_1_VALUE, testConfiguration.getString(PROPERTY_1));
+    }
+
+    @Test
+    public void throwExceptionWhenPropertiesFileIsNotFound() throws IOException {
+        removePropertiesFileFromAllDirectories();
+        expected.expect(IOException.class);
+        SampleConfigurationUtils.getConfiguration(TEST_PROPERTIES_FILE);
+    }
+}

--- a/src/test/resources/com/datalogics/pdf/hsm/samples/util/test.properties
+++ b/src/test/resources/com/datalogics/pdf/hsm/samples/util/test.properties
@@ -1,0 +1,3 @@
+property1=alpha
+property2=beta
+property3=gamma


### PR DESCRIPTION
#### Changes in this pull request

Loads the password from a properties file. The file:
- is named `hsm.properties`
- contains an entry `hsm.password`
- can be located in either the current working directory or the user's home directory
#### Contributes to  [DPJTH-1](https://jira.datalogics.com/browse/DPJTH-1)
#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)
- [x] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [x] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [x] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [x] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)
- [x] Verify that copying files to the user's home directory will not cause problems on an automated build system like Jenkins (consult with @datalogics-kam)
#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:
- [x] _&lt;add your name here with an **@**>_
