### PR TITLE
DLPJTH-6 Add login parameters unit tests

### DIFF
--- a/src/test/java/com/datalogics/pdf/security/HsmLoginParametersTest.java
+++ b/src/test/java/com/datalogics/pdf/security/HsmLoginParametersTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Datalogics Inc.
+ */
+
+package com.datalogics.pdf.security;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit test for HsmLoginParameters class.
+ */
+public class HsmLoginParametersTest {
+    public static final String PASSWORD = "password";
+
+    @Test
+    public void passwordIsRetreiveable() {
+        final HsmLoginParameters parameters = new HsmLoginParameters(PASSWORD);
+        assertEquals("Password does not match", PASSWORD, parameters.getPassword());
+    }
+}

--- a/src/test/java/com/datalogics/pdf/security/LunaHsmLoginParametersTest.java
+++ b/src/test/java/com/datalogics/pdf/security/LunaHsmLoginParametersTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Datalogics Inc.
+ */
+
+package com.datalogics.pdf.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+
+/**
+ * Unit test for LunaHsmLoginParameters class.
+ */
+public class LunaHsmLoginParametersTest {
+    public static final String PASSWORD = "password";
+    public static final String TOKEN_LABEL = "token_label";
+
+    @Test
+    public void tokenLabelIsNullForSingleArgConstructor() {
+        final LunaHsmLoginParameters parameters = new LunaHsmLoginParameters(PASSWORD);
+        assertNull("Token label should be null", parameters.getTokenLabel());
+        assertEquals("Password does not match", PASSWORD, parameters.getPassword());
+    }
+
+    @Test
+    public void tokenLabelIsRetreiveable() {
+        final LunaHsmLoginParameters parameters = new LunaHsmLoginParameters(TOKEN_LABEL, PASSWORD);
+        assertEquals("Token label does not match", TOKEN_LABEL, parameters.getTokenLabel());
+        assertEquals("Password does not match", PASSWORD, parameters.getPassword());
+    }
+}


### PR DESCRIPTION
#### Changes in this pull request

Adds unit tests for the `HsmLoginParameters` and `LunaHsmLoginParameters` classes.
#### Fulfills  [DLPJTH-6](https://jira.datalogics.com/browse/DLPJTH-6)
#### Checklist for approving this pull request

(PR creator amend this with more conditions if necessary)
- [x] There are **unit tests** for new/changed code, or a good explanation why this was not possible.
- [x] All **CI builders** have indicated success (Give them a few minutes to notice the pull request.)
- [x] The **Pull request title** has the JIRA issue numbers separated by spaces (if any), a space, and then a short, but descriptive summary.
- [x] **Commit messages** are well formed: [A note about Git commit messages](http://www.tpope.net/node/106)
- [x] New public packages, classes, and methods are **documented**. (Strongly consider documenting private classes and methods.)
#### Blockers

Add a checkbox for yourself with your **&#64;name** to this list if you are holding this PR open for review. PR Shepherd, please hold off merging this PR until these are all checked:
- [x] _&lt;add your name here with an **@**>_
